### PR TITLE
Fix file name casing for System.Xml.dll

### DIFF
--- a/Microsoft.Net.Compilers/Microsoft.Net.Compilers.1.3.2/tools/vbc.rsp
+++ b/Microsoft.Net.Compilers/Microsoft.Net.Compilers.1.3.2/tools/vbc.rsp
@@ -30,7 +30,7 @@
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
 /r:System.Windows.Forms.dll
-/r:System.XML.dll
+/r:System.Xml.dll
 
 /r:System.Workflow.Activities.dll
 /r:System.Workflow.ComponentModel.dll

--- a/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.0.0/tools/vbc.rsp
+++ b/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.0.0/tools/vbc.rsp
@@ -30,7 +30,7 @@
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
 /r:System.Windows.Forms.dll
-/r:System.XML.dll
+/r:System.Xml.dll
 
 /r:System.Workflow.Activities.dll
 /r:System.Workflow.ComponentModel.dll

--- a/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.7.0/tools/vbc.rsp
+++ b/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.7.0/tools/vbc.rsp
@@ -30,7 +30,7 @@
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
 /r:System.Windows.Forms.dll
-/r:System.XML.dll
+/r:System.Xml.dll
 
 /r:System.Workflow.Activities.dll
 /r:System.Workflow.ComponentModel.dll

--- a/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.8.0/tools/vbc.rsp
+++ b/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.8.0/tools/vbc.rsp
@@ -30,7 +30,7 @@
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
 /r:System.Windows.Forms.dll
-/r:System.XML.dll
+/r:System.Xml.dll
 
 /r:System.Workflow.Activities.dll
 /r:System.Workflow.ComponentModel.dll

--- a/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.8.2/tools/vbc.rsp
+++ b/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.8.2/tools/vbc.rsp
@@ -30,7 +30,7 @@
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
 /r:System.Windows.Forms.dll
-/r:System.XML.dll
+/r:System.Xml.dll
 
 /r:System.Workflow.Activities.dll
 /r:System.Workflow.ComponentModel.dll

--- a/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.9.0/tools/vbc.rsp
+++ b/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.9.0/tools/vbc.rsp
@@ -30,7 +30,7 @@
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
 /r:System.Windows.Forms.dll
-/r:System.XML.dll
+/r:System.Xml.dll
 
 /r:System.Workflow.Activities.dll
 /r:System.Workflow.ComponentModel.dll


### PR DESCRIPTION
Fixes the file name case for `System.Xml.dll`. Upstream change also submitted to Roslyn as https://github.com/dotnet/roslyn/pull/29246